### PR TITLE
Release: v1.0.0-beta.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet-spark",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet-spark",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@buildonspark/bare": "0.0.55",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet-spark",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "A simple package to manage BIP-32 wallets for the Spark blockchain.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.13

### Changes since v1.0.0-beta.12
- Bump spark-sdk dependency (#76)

Made with [Cursor](https://cursor.com)