### PR TITLE
Upgrade Spark/Bare dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "@buildonspark/bare": "^0.0.60",
-        "@buildonspark/spark-sdk": "^0.7.10",
+        "@buildonspark/bare": "^0.0.61",
+        "@buildonspark/spark-sdk": "^0.7.11",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
         "@scure/bip32": "1.7.0",
@@ -530,14 +530,14 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@buildonspark/bare": {
-      "version": "0.0.60",
-      "resolved": "https://registry.npmjs.org/@buildonspark/bare/-/bare-0.0.60.tgz",
-      "integrity": "sha512-sR2+5SMlgrBvPW6NUvOs+Byvz72rxw8X3Nuwigsb6iibFLD5ak3KDD6bgrVmVdoz0wO0424gc1qY4XbTAATEjA==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/@buildonspark/bare/-/bare-0.0.61.tgz",
+      "integrity": "sha512-1/vBc5zCf8kiQ77uQJ2wnIe2sZMN35rmXuAW0S+9GFf0FpQYvMYrsC/iZ0ONAq1Pd/Kf1265X7lMjJcavvHaVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@buildonspark/spark-frost-bare-addon": "0.0.11",
-        "@buildonspark/spark-sdk": "0.7.10",
-        "bare-node-runtime": "^1.1.4"
+        "@buildonspark/spark-sdk": "0.7.11",
+        "bare-node-runtime": "^1.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -550,9 +550,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.7.10.tgz",
-      "integrity": "sha512-dtGoUylJOHH8PlPB3Sks4ph1GApd6zZECEroX+6YHTU/Ztg54XGDXl23eToYnqUhnlhNuaW5QcDWq/YH+WvmMQ==",
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.7.11.tgz",
+      "integrity": "sha512-Kj9Yw7h6bnyUDSdlNyo3ST+71EVbgbxUaMW1YXUjZqwZ4+5/hwFigBmzhv2w6fQvOnfG+vBVXWe4aVkPxNv7Ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "@buildonspark/bare": "0.0.55",
-        "@buildonspark/spark-sdk": "0.7.5",
+        "@buildonspark/bare": "^0.0.60",
+        "@buildonspark/spark-sdk": "^0.7.10",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
         "@scure/bip32": "1.7.0",
         "@tetherto/wdk-wallet": "1.0.0-beta.7",
-        "bare-node-runtime": "^1.1.4",
+        "bare-node-runtime": "^1.2.0",
         "bip39": "3.1.0",
         "sodium-universal": "5.0.1"
       },
@@ -530,13 +530,13 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@buildonspark/bare": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/@buildonspark/bare/-/bare-0.0.55.tgz",
-      "integrity": "sha512-ovuzApUJlsF9REtJiTpFQT1sUcvkCZqyA0j7OviD6ptmdlt8Th1GBptz2NYRi+LmMx+NDOdOE8/IyGmsYbfJhg==",
+      "version": "0.0.60",
+      "resolved": "https://registry.npmjs.org/@buildonspark/bare/-/bare-0.0.60.tgz",
+      "integrity": "sha512-sR2+5SMlgrBvPW6NUvOs+Byvz72rxw8X3Nuwigsb6iibFLD5ak3KDD6bgrVmVdoz0wO0424gc1qY4XbTAATEjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@buildonspark/spark-frost-bare-addon": "0.0.11",
-        "@buildonspark/spark-sdk": "0.7.5",
+        "@buildonspark/spark-sdk": "0.7.10",
         "bare-node-runtime": "^1.1.4"
       },
       "engines": {
@@ -550,9 +550,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.7.5.tgz",
-      "integrity": "sha512-iwEEzL5FA2xLHwXJrbSgs2htDyP2S0/6MUM0mQVGylvesHqdaiIDn6vCfO3CWF87HdPQsK9FfA8hihDrPtElcQ==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.7.10.tgz",
+      "integrity": "sha512-dtGoUylJOHH8PlPB3Sks4ph1GApd6zZECEroX+6YHTU/Ztg54XGDXl23eToYnqUhnlhNuaW5QcDWq/YH+WvmMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/bare-fetch": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-2.8.0.tgz",
-      "integrity": "sha512-xCBF6oKwzZmq+M6FGcAHv8Fn3XEXHeauLr6dfmr5IG07PFhabg1+r9eeVaIybPAqx8syF9M9+4r23QuDvh3Uvg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-2.8.2.tgz",
+      "integrity": "sha512-N0gZH8iuuC36Ygd4Kjfeo90aOKZ19cycbuZWVpm9W+f5v2ks/2qvgVIKp9hRDZSo5imqO097ynJcn4w24F8c/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-form-data": "^1.2.0",
@@ -2450,9 +2450,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
-      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -2486,9 +2486,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-http1": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.5.tgz",
-      "integrity": "sha512-ADITiRo0huP76JGMbv6Arsh9KehHqjEBoYcmjvAo67IY78+/9mV2MeKLLCkiJSFxA85T/m8cTaE44OwJQCcwdw==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.6.tgz",
+      "integrity": "sha512-31OAwMkSU+z1VuUOCk65hx3aWQgzCfH/zQ6LGxbJtmiy2Czsw0+uvOBM9YkqaL6zUSTSYG2pLbL0v/TjME3Buw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.6.0",
@@ -2706,9 +2706,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.6.tgz",
-      "integrity": "sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -2743,19 +2743,18 @@
       }
     },
     "node_modules/bare-process": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.0.tgz",
-      "integrity": "sha512-G5O+Lk1lsPiYjVXP+xS8KUqNzFwibrwvqJ7DO6x8ceLSTwxyMq7NwpbmbGQQZiaiOsdZZHBFs9n+we7OuANhaw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
+      "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-abort": "^2.0.13",
         "bare-env": "^3.0.0",
         "bare-events": "^2.3.1",
-        "bare-fs": "^4.5.6",
         "bare-hrtime": "^2.0.0",
         "bare-os": "^3.7.1",
         "bare-signals": "^4.0.0",
-        "bare-tty": "^5.0.0"
+        "bare-stdio": "^1.0.1"
       }
     },
     "node_modules/bare-punycode": {
@@ -2774,9 +2773,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-readline": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bare-readline/-/bare-readline-1.2.2.tgz",
-      "integrity": "sha512-7MihQDnw80rxPyLJHZAUgFskFyGUj45FKJDIe57sW0iQyJIGroFA08mrtiMLMWUIgSd49hT7E97FCWvrc29p1Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bare-readline/-/bare-readline-1.3.1.tgz",
+      "integrity": "sha512-QtSU4ZfgQcDI6AQssjDFqTiRe4rCiciMn+Yqx6siMJZBIftAIFrNSOK0sa5SBrmNv/a7CD9Dm0onUDCRyn5Fdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-ansi-escapes": "^2.0.0",
@@ -2827,10 +2826,21 @@
         "bare": ">=1.7.0"
       }
     },
+    "node_modules/bare-stdio": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
+      "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.2",
+        "bare-pipe": "^4.1.5",
+        "bare-tty": "^5.0.3"
+      }
+    },
     "node_modules/bare-stream": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
-      "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -2981,9 +2991,9 @@
       }
     },
     "node_modules/bare-tls": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-2.2.1.tgz",
-      "integrity": "sha512-hZ+ZqwrUO4dyH7/6WYkYWjgAFNJKjzwEYJiDaMnMs+eRleBDjQ3CvNZawpkw0Ar9jnM9NZK6+f6GqjkZ2FLGmQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-2.2.3.tgz",
+      "integrity": "sha512-dPYBGEXtgLceRFMfGaF2/rqR86/xMxMyrM9ootO/gaRKL/z2uNHJs7aP7IOBtnJF8eUCt5qwMzbKfrKgDIxPLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-net": "^2.0.1",
@@ -3092,9 +3102,9 @@
       }
     },
     "node_modules/bare-zlib": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/bare-zlib/-/bare-zlib-1.3.1.tgz",
-      "integrity": "sha512-VP93GFzhrTdWh9mXNocn7XsP/nF5JQluiiSsbTvsQ4yIYlhEHRMF9lQmZZDXwzK9PNYaVGUV1bdQuqp0Mj7MHw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/bare-zlib/-/bare-zlib-1.3.3.tgz",
+      "integrity": "sha512-rXNczo+SQg6cn20olmh/mUiGeJK9maipFH/zI/QwYgwhEmOns1R7fl1GV5apNO+aAp4x2d4uUa7HLhO4mhOnBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-stream": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage --testPathIgnorePatterns=integration"
   },
   "dependencies": {
-    "@buildonspark/bare": "0.0.55",
-    "@buildonspark/spark-sdk": "0.7.5",
+    "@buildonspark/bare": "^0.0.60",
+    "@buildonspark/spark-sdk": "^0.7.10",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^2.0.1",
     "@scure/bip32": "1.7.0",
     "@tetherto/wdk-wallet": "1.0.0-beta.7",
-    "bare-node-runtime": "^1.1.4",
+    "bare-node-runtime": "^1.2.0",
     "bip39": "3.1.0",
     "sodium-universal": "5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage --testPathIgnorePatterns=integration"
   },
   "dependencies": {
-    "@buildonspark/bare": "^0.0.60",
-    "@buildonspark/spark-sdk": "^0.7.10",
+    "@buildonspark/bare": "^0.0.61",
+    "@buildonspark/spark-sdk": "^0.7.11",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^2.0.1",
     "@scure/bip32": "1.7.0",


### PR DESCRIPTION
# Description
Upgrade the published Spark Bare dependencies used by `wdk-wallet-spark` and refresh the app's `bare-node-runtime` subtree in `package-lock.json`.

## Motivation and Context
- `@buildonspark/bare` `^0.0.60`
- `@buildonspark/spark-sdk` `^0.7.10`
- `bare-node-runtime` `^1.2.0`

The regenerated lockfile also picks up the latest compatible Bare runtime subtree for the app, including `bare-fetch@2.8.2`, `bare-http1@4.5.6`, `bare-https@2.1.3`, and `bare-tls@2.2.3`.

## Related Issue
PR fixes the following issue:

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
