### PR TITLE
Feature - Sign tx

### DIFF
--- a/src/wallet-account-spark.js
+++ b/src/wallet-account-spark.js
@@ -185,6 +185,20 @@ export default class WalletAccountSpark extends WalletAccountReadOnlySpark {
   }
 
   /**
+   * Signs a transaction.
+   *
+   * Not supported on spark: transfers are signed collaboratively with the spark operators
+   * via a FROST / Statechain protocol, so a signed payload cannot be produced locally and
+   * broadcast independently. Use `sendTransaction` instead.
+   *
+   * @param {SparkTransaction} tx - The transaction.
+   * @returns {Promise<never>} Never resolves; always throws.
+   */
+  async signTransaction (tx) {
+    throw new Error("Method 'signTransaction(tx)' not supported on spark.")
+  }
+
+  /**
    * Sends a transaction.
    *
    * @param {SparkTransaction} tx - The transaction.

--- a/types/src/wallet-account-spark.d.ts
+++ b/types/src/wallet-account-spark.d.ts
@@ -52,6 +52,17 @@ export default class WalletAccountSpark extends WalletAccountReadOnlySpark imple
      */
     sign(message: string): Promise<string>;
     /**
+     * Signs a transaction.
+     *
+     * Not supported on spark: transfers are signed collaboratively with the spark operators
+     * via a FROST / Statechain protocol, so a signed payload cannot be produced locally and
+     * broadcast independently. Use `sendTransaction` instead.
+     *
+     * @param {SparkTransaction} tx - The transaction.
+     * @returns {Promise<never>} Never resolves; always throws.
+     */
+    signTransaction(tx: SparkTransaction): Promise<never>;
+    /**
      * Sends a transaction.
      *
      * @param {SparkTransaction} tx - The transaction.


### PR DESCRIPTION
# Description
Add a new signTransaction method that signs a transaction and returns the raw signed transaction.

## Motivation and Context
Currently, WDK only supports sendTransaction, which signs and broadcasts in one step. Some consumers want to sign a transaction locally and handle broadcasting themselves (e.g. to submit via a different relayer, queue the tx, or inspect it before sending). This new method supports that workflow while leaving sendTransaction unchanged.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
