### PR TITLE
Fix key pair property.

### DIFF
--- a/src/bip-44/spark-signer.js
+++ b/src/bip-44/spark-signer.js
@@ -39,7 +39,7 @@ export default class Bip44SparkSigner extends DefaultSparkSigner {
     if (this.staticDepositKey?.privateKey) sodium_memzero(this.staticDepositKey.privateKey)
     if (this.htlcPreimageKey?.privateKey) sodium_memzero(this.htlcPreimageKey.privateKey)
 
-    this.identityKey = undefined
+    this.identityKey.privateKey = undefined
     this.signingKey = undefined
     this.depositKey = undefined
     this.staticDepositKey = undefined

--- a/src/wallet-account-spark.js
+++ b/src/wallet-account-spark.js
@@ -145,12 +145,16 @@ export default class WalletAccountSpark extends WalletAccountReadOnlySpark {
   /**
    * The account's key pair.
    *
+   * The uint8 arrays are bound to the wallet account, so any external change will reflect to the internal representation. For this reason,
+   * it's strongly recommended to treat the key pair as a read-only view of the keys. While it's still technically possible to alter their
+   * content, client code should never do so.
+   *
    * @type {KeyPair}
    */
   get keyPair () {
     return {
       publicKey: this._signer.identityKey.publicKey,
-      privateKey: this._signer.identityKey.privateKey
+      privateKey: this._signer.identityKey.privateKey ?? null
     }
   }
 

--- a/types/src/wallet-account-spark.d.ts
+++ b/types/src/wallet-account-spark.d.ts
@@ -35,6 +35,10 @@ export default class WalletAccountSpark extends WalletAccountReadOnlySpark imple
     /**
      * The account's key pair.
      *
+     * The uint8 arrays are bound to the wallet account, so any external change will reflect to the internal representation. For this reason,
+     * it's strongly recommended to treat the key pair as a read-only view of the keys. While it's still technically possible to alter their
+     * content, client code should never do so.
+     *
      * @type {KeyPair}
      */
     get keyPair(): KeyPair;


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail. -->
PR updates the key pair property to return the original keys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We shouldn't create a copy of the private key each time the user accesses the key pair property.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->
PR fixes the following issue: -

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
