### PR TITLE
Release: v1.0.0-beta.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet-spark",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet-spark",
-      "version": "1.0.0-beta.20",
+      "version": "1.0.0-beta.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@buildonspark/bare": "0.0.74",
@@ -14,8 +14,8 @@
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "2.2.0",
         "@scure/bip32": "1.7.0",
-        "@tetherto/wdk-wallet": "1.0.0-beta.10",
-        "bare-node-runtime": "^1.4.0",
+        "@tetherto/wdk-wallet": "1.0.0-beta.11",
+        "bare-node-runtime": "^1.5.0",
         "bip39": "3.1.0",
         "sodium-universal": "5.0.1"
       },
@@ -24,7 +24,7 @@
         "jest": "29.7.0",
         "rimraf": "6.1.3",
         "standard": "17.1.2",
-        "typescript": "5.8.3"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -58,7 +58,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1283,9 +1282,9 @@
       }
     },
     "node_modules/@tetherto/wdk-wallet": {
-      "version": "1.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.10.tgz",
-      "integrity": "sha512-qCOxvNIltfwwMhOjWAgk2DN/0TZ+RjNOk10BXKQM2XMmq6KR8yJZV3Yc5FoJ+AFsCHZBhVJR6k6eF0/ZMI1pIA==",
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.11.tgz",
+      "integrity": "sha512-4KxZxIU3t7aQ7bdgB0UTM4LfLB/PvuLXqJ/AkTTP0MzhyJcJ8CtuYBT+fCnh4KNWSizPGmCqZNBGITYHyKwiug==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",
@@ -1409,7 +1408,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1795,7 +1793,6 @@
     "node_modules/bare-abort-controller": {
       "version": "1.1.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -2194,9 +2191,9 @@
       }
     },
     "node_modules/bare-node-runtime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.4.0.tgz",
-      "integrity": "sha512-/mYhg/vJSnrBlz1CFKjgihT7PoChbYFsxjUf7mEas7997ty/dQ4plyzhn17TF/u163Of8hvil+ZWFF7amApl9A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bare-node-runtime/-/bare-node-runtime-1.5.0.tgz",
+      "integrity": "sha512-eMRq9WDYd+E0IZ8EG/8iCozZJl511z6vp7kxZyxjDw77ggOZ7bThFpJ72Kztjs8sh0hoe+xhFyZmoqAdVE/Ziw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-abort-controller": "^1.0.0",
@@ -2469,7 +2466,6 @@
     "node_modules/bare-tcp": {
       "version": "2.2.7",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-dns": "^2.0.4",
         "bare-events": "^2.5.4",
@@ -2695,7 +2691,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3418,7 +3413,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3606,7 +3600,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3658,7 +3651,6 @@
       "version": "15.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -3694,7 +3686,6 @@
       "version": "6.6.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3709,7 +3700,6 @@
       "version": "7.37.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -4394,7 +4384,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -7580,7 +7569,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7893,7 +7884,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet-spark",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "description": "A simple package to manage BIP-32 wallets for the Spark blockchain.",
   "keywords": [
     "wdk",
@@ -32,8 +32,8 @@
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "2.2.0",
     "@scure/bip32": "1.7.0",
-    "@tetherto/wdk-wallet": "1.0.0-beta.10",
-    "bare-node-runtime": "^1.4.0",
+    "@tetherto/wdk-wallet": "1.0.0-beta.11",
+    "bare-node-runtime": "^1.5.0",
     "bip39": "3.1.0",
     "sodium-universal": "5.0.1"
   },
@@ -42,7 +42,7 @@
     "jest": "29.7.0",
     "rimraf": "6.1.3",
     "standard": "17.1.2",
-    "typescript": "5.8.3"
+    "typescript": "5.9.3"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
- Bump version to 1.0.0-beta.21

### Changes since v1.0.0-beta.20
- Align Spark with the `transactionMaxFee` rollout; Spark keeps no fee enforcement because the chain has no fees (#96)

### Dependency updates
- @tetherto/wdk-wallet: 1.0.0-beta.10 -> 1.0.0-beta.11
- bare-node-runtime: ^1.4.0 -> ^1.5.0
- typescript: 5.8.3 -> 5.9.3
- npm audit fix applied; remaining findings require breaking/force updates or upstream dependency fixes

Made with [Cursor](https://cursor.com)