### PR TITLE
Release: v1.0.0-beta.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@tetherto/wdk-wallet-spark",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet-spark",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "license": "Apache-2.0",
       "dependencies": {
-        "@buildonspark/bare": "0.0.74",
-        "@buildonspark/spark-sdk": "0.8.6",
+        "@buildonspark/bare": "0.0.76",
+        "@buildonspark/spark-sdk": "0.8.8",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "2.2.0",
         "@scure/bip32": "1.7.0",
@@ -486,17 +486,19 @@
       "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@buildonspark/bare": {
-      "version": "0.0.74",
-      "resolved": "https://registry.npmjs.org/@buildonspark/bare/-/bare-0.0.74.tgz",
-      "integrity": "sha512-ooEDx72cRHbLjF2SdyKN4pjQt4ntHHdF7LEwT+Y9CjyddONfbsz5ObjGzvY/hdXKRwdp6xfxbi2hv9hfk5vxqA==",
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@buildonspark/bare/-/bare-0.0.76.tgz",
+      "integrity": "sha512-Zsccbdbh5iB4bcXE1m05BMdeAuG3DGjQYTsDj73iPKq2YRa0TTDQpGheQn41ZHeKClwUDyBEgS40TGjQrCKZoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@buildonspark/spark-frost-bare-addon": "0.0.12",
-        "@buildonspark/spark-sdk": "0.8.6",
+        "@buildonspark/spark-sdk": "0.8.8",
         "bare-node-runtime": "^1.2.0"
       },
       "engines": {
@@ -510,9 +512,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.8.6.tgz",
-      "integrity": "sha512-rpdmeDvGtXzOmRTGuGUH7HK5fJjLUbPmD01agHry/rdpdzLH/F8eHznmqK1YD/m8EvQ5l0FP/UKxfo01ehNcqw==",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.8.8.tgz",
+      "integrity": "sha512-RphV/NgCofPYN13ZiiSd9EAXRCovLtTY7V2jxgPp1+oE8fX93R86zC5wCoYd+y9TpB41uoxZQvv60Zb1Bwc88g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
@@ -536,7 +538,6 @@
         "nice-grpc-client-middleware-retry": "^3.1.10",
         "nice-grpc-common": "^2.0.2",
         "nice-grpc-web": "^3.3.7",
-        "ts-proto": "2.8.3",
         "ua-parser-js": "^2.0.6",
         "uuidv7": "^1.0.2"
       },
@@ -1045,6 +1046,8 @@
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1053,6 +1056,8 @@
     },
     "node_modules/@lightsparkdev/core": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-7EiV/Ld+IqAQJYvSLN2gS6E/UrcCCQ/H4voUz+nAPUDSk8U1P06afTKALh1FeizAXIzqxt1jFQWmQlXPSXmxIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -1135,14 +1140,20 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1162,24 +1173,26 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rtsao/scc": {
@@ -1218,6 +1231,8 @@
     },
     "node_modules/@scure/bip39": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.8.0",
@@ -1229,6 +1244,8 @@
     },
     "node_modules/@scure/bip39/node_modules/@noble/hashes": {
       "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1239,6 +1256,8 @@
     },
     "node_modules/@scure/btc-signer": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-1.8.1.tgz",
+      "integrity": "sha512-8nX9T++dFyKpvqksNHfSi9CgRsGnHAQtCdIQ1y1GmbCGLpV97v4MUyemUUT6uDumKL3oo3m4niyY6A32nmdLuQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.9.0",
@@ -1252,6 +1271,8 @@
     },
     "node_modules/@scure/btc-signer/node_modules/@noble/hashes": {
       "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1389,6 +1410,8 @@
     },
     "node_modules/@types/zen-observable": {
       "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -1398,10 +1421,14 @@
     },
     "node_modules/abort-controller-x": {
       "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
+      "integrity": "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==",
       "license": "MIT"
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
+      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
       "license": "MIT"
     },
     "node_modules/acorn": {
@@ -1646,6 +1673,8 @@
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2605,6 +2634,8 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -2715,6 +2746,8 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -2839,16 +2872,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3129,6 +3152,8 @@
     },
     "node_modules/detect-europe-js": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
       "funding": [
         {
           "type": "github",
@@ -3144,16 +3169,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3180,13 +3195,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dprint-node": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^1.0.3"
       }
     },
     "node_modules/dunder-proto": {
@@ -3961,6 +3969,8 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/events-universal": {
@@ -4390,6 +4400,8 @@
     },
     "node_modules/graphql-ws": {
       "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4493,6 +4505,8 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -4880,6 +4894,8 @@
     },
     "node_modules/is-standalone-pwa": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
       "funding": [
         {
           "type": "github",
@@ -5004,6 +5020,8 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -5637,6 +5655,8 @@
     },
     "node_modules/js-base64": {
       "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
@@ -5755,6 +5775,8 @@
     },
     "node_modules/light-bolt11-decoder": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/light-bolt11-decoder/-/light-bolt11-decoder-3.2.0.tgz",
+      "integrity": "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==",
       "license": "MIT",
       "dependencies": {
         "@scure/base": "1.1.1"
@@ -5762,6 +5784,8 @@
     },
     "node_modules/light-bolt11-decoder/node_modules/@scure/base": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
       "funding": [
         {
           "type": "individual",
@@ -5831,6 +5855,8 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -5840,6 +5866,8 @@
     },
     "node_modules/long": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -5911,6 +5939,8 @@
     },
     "node_modules/micro-packed": {
       "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.3.tgz",
+      "integrity": "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==",
       "license": "MIT",
       "dependencies": {
         "@scure/base": "~1.2.5"
@@ -5978,6 +6008,8 @@
     },
     "node_modules/nice-grpc": {
       "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.16.tgz",
+      "integrity": "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.0",
@@ -5987,6 +6019,8 @@
     },
     "node_modules/nice-grpc-client-middleware-retry": {
       "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.15.tgz",
+      "integrity": "sha512-fXfNNdtjCQzc3O/w3WsK1AOU+xdE1V7FCm4FEQWS/UUVsV1616S2oryvWqsZAF8aOvuMir8lFtNmgH3DeP+PBg==",
       "license": "MIT",
       "dependencies": {
         "abort-controller-x": "^0.5.0",
@@ -5995,10 +6029,14 @@
     },
     "node_modules/nice-grpc-client-middleware-retry/node_modules/abort-controller-x": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
       "license": "MIT"
     },
     "node_modules/nice-grpc-common": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.3.tgz",
+      "integrity": "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==",
       "license": "MIT",
       "dependencies": {
         "ts-error": "^1.0.6"
@@ -6006,6 +6044,8 @@
     },
     "node_modules/nice-grpc-web": {
       "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-3.3.10.tgz",
+      "integrity": "sha512-8XyCtbs7uL0mWQEjpkjZy57bnLbtheRbIWgj8p98XPbjFqXOBkTLu+ebj5H4fUu/yxqt+6ULPPDHT/icUsyieA==",
       "license": "MIT",
       "dependencies": {
         "abort-controller-x": "^0.5.0",
@@ -6016,10 +6056,14 @@
     },
     "node_modules/nice-grpc-web/node_modules/abort-controller-x": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
       "license": "MIT"
     },
     "node_modules/nice-grpc/node_modules/abort-controller-x": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
       "license": "MIT"
     },
     "node_modules/node-exports-info": {
@@ -6547,9 +6591,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
-      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6559,7 +6603,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -7405,34 +7448,9 @@
     },
     "node_modules/ts-error": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+      "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
-    },
-    "node_modules/ts-poet": {
-      "version": "6.12.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dprint-node": "^1.0.8"
-      }
-    },
-    "node_modules/ts-proto": {
-      "version": "2.8.3",
-      "license": "ISC",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.0.0",
-        "case-anything": "^2.1.13",
-        "ts-poet": "^6.12.0",
-        "ts-proto-descriptors": "2.0.0"
-      },
-      "bin": {
-        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
-      }
-    },
-    "node_modules/ts-proto-descriptors": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.0.0"
-      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -7466,6 +7484,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -7584,6 +7604,8 @@
     },
     "node_modules/ua-is-frozen": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
       "funding": [
         {
           "type": "github",
@@ -7706,6 +7728,8 @@
     },
     "node_modules/uuidv7": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-1.2.1.tgz",
+      "integrity": "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==",
       "license": "Apache-2.0",
       "bin": {
         "uuidv7": "cli.js"
@@ -7958,10 +7982,14 @@
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
       "license": "MIT"
     },
     "node_modules/zen-observable-ts": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
       "license": "MIT",
       "dependencies": {
         "@types/zen-observable": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet-spark",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "description": "A simple package to manage BIP-32 wallets for the Spark blockchain.",
   "keywords": [
     "wdk",
@@ -27,8 +27,8 @@
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage --testPathIgnorePatterns=integration"
   },
   "dependencies": {
-    "@buildonspark/bare": "0.0.74",
-    "@buildonspark/spark-sdk": "0.8.6",
+    "@buildonspark/bare": "0.0.76",
+    "@buildonspark/spark-sdk": "0.8.8",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "2.2.0",
     "@scure/bip32": "1.7.0",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.22

### Changes since v1.0.0-beta.21
- No code changes — Spark SDK dependency update only

### Dependency updates
- `@buildonspark/spark-sdk`: 0.8.6 → 0.8.8
- `@buildonspark/bare`: 0.0.74 → 0.0.76
- npm audit fix skipped — no non-breaking fixes available (js-yaml via jest devDependency chain)

Made with [Cursor](https://cursor.com)